### PR TITLE
Feat/hub 121/set env variables

### DIFF
--- a/src/hub_client/config.py
+++ b/src/hub_client/config.py
@@ -2,3 +2,4 @@ import os
 
 HUB_API_ROOT = os.environ.get('ULTRALYTICS_HUB_API', 'https://api.ultralytics.com')
 HUB_WEB_ROOT = os.environ.get('ULTRALYTICS_HUB_WEB', 'https://hub.ultralytics.com')
+HUB_FUNCTIONS_ROOT = os.environ.get('ULTRALYTICS_HUB_FUNCTIONS', 'https://europe-west1-ultralytics-hub-staging.cloudfunctions.net/')


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

copilot:all


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced configuration flexibility for Ultralytics Hub SDK.

### 📊 Key Changes
- Added a new environment variable `ULTRALYTICS_HUB_FUNCTIONS`.
- Set a default URL for Hub functions pointing to a staging environment in `europe-west1`.

### 🎯 Purpose & Impact
- **Purpose**: To allow SDK users to easily configure and connect to different Ultralytics Hub functions through environment variables.
- **Impact**: Provides better integration with Ultralytics Hub services, facilitating development and testing by enabling switching between environments (e.g., staging vs. production) without code changes. 🔄 Users can expect more streamlined updates and feature rollouts.