### PR TITLE
fix: quick-fix-for-export

### DIFF
--- a/hub_sdk/base/server_clients.py
+++ b/hub_sdk/base/server_clients.py
@@ -91,7 +91,7 @@ class ModelUpload(APIClient):
         try:
             payload = {'format': format}
             endpoint = f"/{id}/export"
-            return self._handle_request(self.api_client.post, endpoint, payload)
+            return self.post(endpoint, json=payload)
         except Exception as e:
             self.logger.error(f"Failed to export file for {self.name}: %s", e)
             raise e


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

copilot:all
- Quick Fix for export
- remove handle_request

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced internal API call for exporting files within the Ultralytics SDK.

### 📊 Key Changes
- Streamlined the method to export files, altering the direct use of `api_client.post` to the encapsulated `self.post` method.

### 🎯 Purpose & Impact
- The change is aimed at improving code consistency and maintainability.
- Users should notice no difference in functionality, but the SDK codebase is now slightly cleaner, potentially reducing future bugs or issues related to file exports. 🛠️🔧