### PR TITLE
fix: FIREBASE_AUTH_URL request added headers

### DIFF
--- a/hub_sdk/base/auth.py
+++ b/hub_sdk/base/auth.py
@@ -1,7 +1,7 @@
 from distutils.sysconfig import PREFIX
 from hub_sdk.helpers.logger import logger
 import requests
-from hub_sdk.config import FIREBASE_AUTH_URL, HUB_API_ROOT
+from hub_sdk.config import FIREBASE_AUTH_URL, HUB_API_ROOT, HUB_WEB_ROOT
 
 class Auth:
     def __init__(self):
@@ -73,7 +73,8 @@ class Auth:
             bool: True if authorization is successful, False otherwise.
         """
         try:
-            response = requests.post(FIREBASE_AUTH_URL, json={"email": email, "password": password})
+            headers = {"origin": HUB_WEB_ROOT}
+            response = requests.post(FIREBASE_AUTH_URL, json={"email": email, "password": password}, headers=headers)
             if response.status_code == 200:
                 self.id_token = response.json().get("idToken")
                 return True


### PR DESCRIPTION
<!--
Thank you 🙏 for submitting a Pull Request to an Ultralytics 🚀 repo! We want to make contributing as possible. A few tips to get you started:

- Search existing PRs to see if a similar contribution already exists.
- Link this PR to an open Issue to help us understand what bug fix or feature is being implemented.
- Sign the Ultralytics Contributor License Agreement (CLA) by writing the below statement in a PR comment:  
I have read the CLA Document and I sign the CLA

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/ultralytics/blob/master/CONTRIBUTING.md) for more details.

Note that Copilot will summarize this PR below, do not modify the 'copilot:all' line.
-->

copilot:all

- Firebase api (accounts:signInWithPassword) required origin header .
- Added headers `{"origin": HUB_WEB_ROOT}`