### PR TITLE
fix: correct key names to match server

### DIFF
--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -136,7 +136,7 @@ class Models(CRUDClient):
         Returns:
             bool: True if resumable, False otherwise.
         """
-        return self.data.get("status") == "training"
+        return self.data.get("has_last_weights", False)
 
     def has_best_weights(self) -> bool:
         """
@@ -145,7 +145,7 @@ class Models(CRUDClient):
         Returns:
             bool: True if best weights available, False otherwise.
         """
-        return self.is_trained() and bool(self.data.get("weights"))
+        return self.data.get("has_best_weights", False)
 
     def is_pretrained(self) -> bool:
         """
@@ -154,7 +154,7 @@ class Models(CRUDClient):
         Returns:
             bool: True if pretrained, False otherwise.
         """
-        return self.data.get("isPretrained", False)
+        return self.data.get("is_pretrained", False)
 
     def is_trained(self) -> bool:
         """
@@ -172,7 +172,7 @@ class Models(CRUDClient):
         Returns:
             bool: True if custom, False otherwise.
         """
-        return self.data.get("isCustom", False)
+        return self.data.get("is_custom", False)
 
     def get_architecture(self) -> str:
         """


### PR DESCRIPTION
This PR corrects the key names for the response returned by the server.


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced model property checks in the hub-sdk.

### 📊 Key Changes
- Changed the `is_resumable` method to check for `has_last_weights` instead of checking the status for "training".
- Updated the `has_best_weights` method to directly check a new flag `has_best_weights` rather than deriving from other properties.
- Standardized boolean property names in `is_pretrained` and `is_custom` methods to `is_pretrained` and `is_custom` for consistency.

### 🎯 Purpose & Impact
- 🛠️ **Improved Consistency**: Property names and checks are now more consistent and self-descriptive, reducing confusion.
- ⏩ **Efficient Checks**: Direct property checks may improve efficiency when querying model states.
- 🧑‍💻 **Better Developer Experience**: Clearer property names can help developers understand the SDK capabilities faster.
- 📈 **Potential for More Accurate Model State Reporting**: By using more explicit flags, models' states might be represented more accurately in the hub.