### PR TITLE
fix: correct typo in dictionary get

### DIFF
--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -203,7 +203,7 @@ class Models(CRUDClient):
             str or None: The URL of the specified weights or None if not available.
         """
         if weight == "last":
-            return self.data("resume")
+            return self.data.get("resume")
 
         return self.data.get("weights")
 


### PR DESCRIPTION
This PR fixes a typo which prevented the weights pass from being fetched when attempting to resume training.