### PR TITLE
Fix/hub 550/get dataset download url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 ./venv
 **venv**
 .DS_Store

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -92,7 +92,7 @@ datasetId = "<Dataset ID>"  # Don't forget to replace this with the actual datas
 dataset = client.dataset(datasetId)
 
 # Retrieve the URL for downloading dataset contents
-url = dataset.get_download_link("archive")
+url = dataset.get_download_link()
 print("Download URL:", url)
 ```
 

--- a/hub_sdk/hub_client.py
+++ b/hub_sdk/hub_client.py
@@ -94,7 +94,7 @@ class HUBClient(Auth):
         return Models(model_id, self.get_auth_header())
 
     @require_authentication
-    def dataset(self, dataset_id: str = None) -> DatasetList:
+    def dataset(self, dataset_id: str = None) -> Datasets:
         """
         Returns an instance of the Datasets class for interacting with datasets.
 

--- a/hub_sdk/modules/datasets.py
+++ b/hub_sdk/modules/datasets.py
@@ -110,25 +110,15 @@ class Datasets(CRUDClient):
         """
         return self.hub_client.upload_dataset(self.id, file)
 
-    def get_download_link(self, type: str) -> Optional[str]:
+    def get_download_link(self) -> Optional[str]:
         """
         Get dataset download link.
-
-        Args:
-            type (str):
 
         Returns:
             (Optional[str]): Return download link or None if the link is not available.
         """
-        try:
-            payload = {"collection": "datasets", "docId": self.id, "object": type}
-            endpoint = f"{HUB_FUNCTIONS_ROOT}/v1/storage"
-            response = self.post(endpoint, json=payload)
-            json = response.json()
-            return json.get("data", {}).get("url")
-        except Exception as e:
-            self.logger.error(f"Failed to download file file for {self.name}: %s", e)
-            raise e
+        return self.data.get("url")
+        
 
 
 class DatasetList(PaginatedList):


### PR DESCRIPTION
- This PR is to remove the request logic from dataset.get_download_ling() and get it from read data.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Optimized dataset downloading and streamlined dataset module in Ultralytics' hub-sdk.

### 📊 Key Changes
- Added the `.idea` folder to `.gitignore` to prevent IDE config files from being tracked.
- Simplified code for retrieving the dataset download URL in `docs/dataset.md`.
- Updated the return type of the `dataset` method from `DatasetList` to `Datasets` in `hub_client.py`.
- Removed an unnecessary payload build-up and request to the back end in `get_download_link` function in `datasets.py`, now it retrieves the URL directly from the `data` attribute.

### 🎯 Purpose & Impact
- The `.gitignore` change avoids unnecessary files in the repository, keeping it clean for all contributors 🧹.
- The simplified dataset download URL code makes it more user-friendly for developers to work with while integrating datasets within their projects 🛠️.
- Changing the `dataset` method's return type provides clarity and consistency in the SDK's API design 💡.
- Streamlining the `get_download_link` function improves the efficiency and reliability of downloading datasets, enhancing the overall user experience 🚀.