### PR TITLE
Transfer `PREFIX` to fix Python 3.12 bug

### DIFF
--- a/hub_sdk/base/auth.py
+++ b/hub_sdk/base/auth.py
@@ -1,11 +1,10 @@
 # Ultralytics HUB-SDK 🚀, AGPL-3.0 License
 
 from typing import Optional
-from distutils.sysconfig import PREFIX
 
 import requests
 
-from hub_sdk.config import FIREBASE_AUTH_URL, HUB_API_ROOT, HUB_WEB_ROOT
+from hub_sdk.config import FIREBASE_AUTH_URL, HUB_API_ROOT, HUB_WEB_ROOT, PREFIX
 from hub_sdk.helpers.error_handler import ErrorHandler
 from hub_sdk.helpers.logger import logger
 

--- a/hub_sdk/config.py
+++ b/hub_sdk/config.py
@@ -13,3 +13,6 @@ FIREBASE_AUTH_URL = os.environ.get(
 HUB_FUNCTIONS_ROOT = f"{HUB_API_ROOT}"
 
 HUB_EXCEPTIONS = os.getenv("ULTRALYTICS_HUB_EXCEPTIONS", "true").lower() == "true"
+
+# Prefix to be used for console printouts
+PREFIX = "Ultralytics HUB-SDK:"


### PR DESCRIPTION
Eliminated `distutils` which appear to be the cause of the Python 3.12 crashes in the Python-OS Matrix tests in https://github.com/ultralytics/hub/actions/runs/7950366627/job/21702597624?pr=321

<!--
Thank you 🙏 for your contribution to [Ultralytics](https://ultralytics.com) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. **Check for Existing Contributions**: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. **Link Related Issues**: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. **Elaborate Your Changes**: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. **Ultralytics Contributor License Agreement (CLA)**: To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    _I have read the CLA Document and I hereby sign the CLA_

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing). Your adherence to these guidelines ensures a faster and more effective review process.
--->
