### PR TITLE
Resolved Unable to List Public Datasets, Projects and Models

### DIFF
--- a/hub_sdk/base/paginated_list.py
+++ b/hub_sdk/base/paginated_list.py
@@ -7,7 +7,7 @@ from hub_sdk.config import HUB_FUNCTIONS_ROOT
 
 
 class PaginatedList(APIClient):
-    def __init__(self, base_endpoint, name, page_size=None, headers=None):
+    def __init__(self, base_endpoint, name, page_size=None, public=None, headers=None):
         """
         Initialize a PaginatedList instance.
 
@@ -20,6 +20,7 @@ class PaginatedList(APIClient):
         super().__init__(f"{HUB_FUNCTIONS_ROOT}/v1/{base_endpoint}", headers)
         self.name = name
         self.page_size = page_size
+        self.public = public
         self.pages = [None]
         self.current_page = 0
         self.total_pages = 1
@@ -99,6 +100,8 @@ class PaginatedList(APIClient):
                 params["lastRecordId"] = last_record
             if query:
                 params["query"] = query
+            if self.public is not None:
+                params['public'] = self.public
             return self.get("", params=params)
         except Exception as e:
             self.logger.error(f"Failed to list {self.name}: %s", e)

--- a/hub_sdk/base/paginated_list.py
+++ b/hub_sdk/base/paginated_list.py
@@ -101,7 +101,7 @@ class PaginatedList(APIClient):
             if query:
                 params["query"] = query
             if self.public is not None:
-                params['public'] = self.public
+                params["public"] = self.public
             return self.get("", params=params)
         except Exception as e:
             self.logger.error(f"Failed to list {self.name}: %s", e)

--- a/hub_sdk/modules/datasets.py
+++ b/hub_sdk/modules/datasets.py
@@ -142,6 +142,4 @@ class DatasetList(PaginatedList):
             headers (dict, optional): Headers to be included in API requests.
         """
         base_endpoint = "datasets"
-        if public:
-            base_endpoint = f"public/{base_endpoint}"
-        super().__init__(base_endpoint, "dataset", page_size, headers)
+        super().__init__(base_endpoint, "dataset", page_size, public, headers)

--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -397,6 +397,4 @@ class ModelList(PaginatedList):
             headers (dict, optional): Headers to be included in API requests.
         """
         base_endpoint = "models"
-        if public:
-            base_endpoint = f"public/{base_endpoint}"
-        super().__init__(base_endpoint, "model", page_size, headers)
+        super().__init__(base_endpoint, "model", page_size, public, headers)

--- a/hub_sdk/modules/projects.py
+++ b/hub_sdk/modules/projects.py
@@ -121,6 +121,4 @@ class ProjectList(PaginatedList):
             headers (dict, optional): Headers to be included in API requests.
         """
         base_endpoint = "projects"
-        if public:
-            base_endpoint = f"public/{base_endpoint}"
-        super().__init__(base_endpoint, "project", page_size, headers)
+        super().__init__(base_endpoint, "project", page_size, public, headers)


### PR DESCRIPTION
This PR is to resolve the issue for listing Public Datasets, Models and Projects
Resolved Tickets:
- https://ultralytics.atlassian.net/browse/HUB-674
- https://ultralytics.atlassian.net/browse/HUB-674

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhanced flexibility for listing public and private resources in the Ultralytics SDK.

### 📊 Key Changes
- 🛠 Added a `public` parameter to the constructors of `PaginatedList`, `datasets`, `models`, and `projects` modules.
- 🧰 Modified `list` method in `PaginatedList` to accept the `public` parameter, allowing it to filter resources based on their visibility.
- ✂️ Removed logic that alters the base endpoint based on the `public` attribute in the `datasets`, `models`, and `projects` modules.

### 🎯 Purpose & Impact
- 🚀 **Purpose**: The introduction of the `public` parameter streamlines how developers can query both public and private resources, providing a more unified and clearer interface.
- 🌍 **Impact to Users**: Users can now easily switch between accessing public and private resources in their applications, enhancing the SDK's usability and flexibility. This change makes it even more straightforward for developers to tailor their queries to specific needs, resulting in a more efficient development process.