### PR TITLE
Unable to Retrieve Direct Download URL of Model Using HUB SDK

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -110,15 +110,15 @@ model = client.model(modelId)
 model.export(format="pyTorch")  # Exports the model as a PyTorch file
 ```
 
-## Retrieve a Direct Download URL
+## Retrieve a Direct Weight URL
 
-Occasionally, you might require direct access to your model's remotely-stored artifacts. This convenient function provides a URL to access and download specific files like your best-performing model weights.
+Occasionally, you might require direct access to your model's remotely-stored artifacts. This convenient function provides a URL to access specific files like your best-performing model weights.
 
 ```python
 modelId = "<Model ID>"
 model = client.model(modelId)
-download_url = model.get_download_link("best")  # Retrieves the download link for the best model checkpoint
-print("Model download link:", download_url)  # Prints out the download link
+weight_url = model.get_weights_url("best")  # Retrieves the URL for the model's optimal checkpoint weights. By default, it returns the URL for the best weights. To obtain the most recent weights, specify 'last.
+print("Weight URL link:", weight_url)  # Prints out the weight url link
 ```
 
 ## Upload a Model Checkpoint

--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -305,23 +305,6 @@ class Models(CRUDClient):
         """
         return self.hub_client.upload_metrics(self.id, metrics)  # response
 
-    def get_download_link(self, type: str) -> str:
-        """
-        Get model download link.
-
-        Args:
-            type (str):
-        """
-        try:
-            payload = {"collection": "models", "docId": self.id, "object": type}
-            endpoint = f"{HUB_FUNCTIONS_ROOT}/v1/storage"
-            response = self.post(endpoint, json=payload)
-            json = response.json()
-            return json.get("data", {}).get("url")
-        except Exception as e:
-            self.logger.error(f"Failed to download link for {self.name}: %s", e)
-            raise e
-
     def start_heartbeat(self, interval: int = 60):
         """
         Starts sending heartbeat signals to a remote hub server.


### PR DESCRIPTION
We are no longer using the get_download_link function in our SDK; instead, we are utilizing get_weight_url.  I have updated the MkDocs documentation, removing mentions of get_download_link and including details regarding get_weight_url