### PR TITLE
Unable to Retrieve Direct Download URL of Dataset Using HUB SDK

### DIFF
--- a/hub_sdk/modules/datasets.py
+++ b/hub_sdk/modules/datasets.py
@@ -110,25 +110,14 @@ class Datasets(CRUDClient):
         """
         return self.hub_client.upload_dataset(self.id, file)
 
-    def get_download_link(self, type: str) -> Optional[str]:
+    def get_download_link(self) -> Optional[str]:
         """
         Get dataset download link.
-
-        Args:
-            type (str):
 
         Returns:
             (Optional[str]): Return download link or None if the link is not available.
         """
-        try:
-            payload = {"collection": "datasets", "docId": self.id, "object": type}
-            endpoint = f"{HUB_FUNCTIONS_ROOT}/v1/storage"
-            response = self.post(endpoint, json=payload)
-            json = response.json()
-            return json.get("data", {}).get("url")
-        except Exception as e:
-            self.logger.error(f"Failed to download file file for {self.name}: %s", e)
-            raise e
+        return self.data.get("url")
 
 
 class DatasetList(PaginatedList):


### PR DESCRIPTION
Fetching the download URL directly from the Firebase Datasets get API instead of making a call to the storage API endpoint.