### PR TITLE
pagination issues with hub-sdk

### DIFF
--- a/hub_sdk/base/api_client.py
+++ b/hub_sdk/base/api_client.py
@@ -105,10 +105,10 @@ class APIClient:
         except requests.exceptions.RequestException as e:
             status_code = None
             # To handle Timeout and ConnectionError exceptions
-            if hasattr(e, "response") and e.response:
+            if hasattr(e, "response") and e.response is not None:
                 status_code = e.response.status_code
 
-            error_msg = ErrorHandler(status_code).handle()
+            error_msg = ErrorHandler(status_code, headers=response.headers).handle()
             self.logger.error(error_msg)
 
             if not HUB_EXCEPTIONS:

--- a/hub_sdk/base/paginated_list.py
+++ b/hub_sdk/base/paginated_list.py
@@ -1,12 +1,13 @@
 # Ultralytics HUB-SDK 🚀, AGPL-3.0 License
 
+import math
 from typing import Optional
 
 from requests import Response
 
 from hub_sdk.base.api_client import APIClient
 from hub_sdk.config import HUB_FUNCTIONS_ROOT
-import math
+
 
 class PaginatedList(APIClient):
     def __init__(self, base_endpoint, name, page_size=None, public=None, headers=None):
@@ -78,9 +79,7 @@ class PaginatedList(APIClient):
             self.total_pages = math.ceil(resp_data.get("total") / self.page_size) if self.page_size > 0 else 0
             last_record_id = resp_data.get("lastRecordId")
             if last_record_id is None:
-                self.pages[self.current_page + 1 :] = [None] * (
-                    len(self.pages) - self.current_page - 1
-                )
+                self.pages[self.current_page + 1 :] = [None] * (len(self.pages) - self.current_page - 1)
             elif len(self.pages) <= self.current_page + 1:
                 self.pages.append(last_record_id)
             else:
@@ -88,9 +87,7 @@ class PaginatedList(APIClient):
         else:
             self.results = {}
             self.total_pages = 0
-            self.pages[self.current_page + 1 :] = [None] * (
-                len(self.pages) - self.current_page - 1
-            )
+            self.pages[self.current_page + 1 :] = [None] * (len(self.pages) - self.current_page - 1)
 
     def list(self, page_size: int = 10, last_record=None, query=None) -> Optional[Response]:
         """

--- a/hub_sdk/helpers/error_handler.py
+++ b/hub_sdk/helpers/error_handler.py
@@ -1,8 +1,9 @@
 # Ultralytics HUB-SDK 🚀, AGPL-3.0 License
 
+import datetime
 import http.client
 from typing import Optional
-import datetime
+
 
 class ErrorHandler:
     """
@@ -73,10 +74,10 @@ class ErrorHandler:
             rate_reset = self.headers.get("X-RateLimit-Reset")
 
             try:
-                reset_time = datetime.datetime.fromtimestamp(int(rate_reset)).strftime('%Y-%m-%d %H:%M:%S')
+                reset_time = datetime.datetime.fromtimestamp(int(rate_reset)).strftime("%Y-%m-%d %H:%M:%S")
             except ValueError:
-                reset_time = 'unknown'
-                
+                reset_time = "unknown"
+
             error_msg = f"You have exceeded the rate limits for this request. You will be able to make requests again after {reset_time}."
         return error_msg
 

--- a/hub_sdk/hub_client.py
+++ b/hub_sdk/hub_client.py
@@ -142,7 +142,7 @@ class HUBClient(Auth):
         return Users(user_id, self.get_auth_header())
 
     @require_authentication
-    def model_list(self, page_size: Optional[int] = None, public: Optional[bool] = None) -> ModelList:
+    def model_list(self, page_size: Optional[int] = 10, public: Optional[bool] = None) -> ModelList:
         """
         Returns a ModelList instance for interacting with a list of models.
 
@@ -156,7 +156,7 @@ class HUBClient(Auth):
         return ModelList(page_size, public, self.get_auth_header())
 
     @require_authentication
-    def project_list(self, page_size: Optional[int] = None, public: Optional[bool] = None) -> ProjectList:
+    def project_list(self, page_size: Optional[int] = 10, public: Optional[bool] = None) -> ProjectList:
         """
         Returns a ProjectList instance for interacting with a list of projects.
 
@@ -170,7 +170,7 @@ class HUBClient(Auth):
         return ProjectList(page_size, public, self.get_auth_header())
 
     @require_authentication
-    def dataset_list(self, page_size: Optional[int] = None, public: Optional[bool] = None) -> DatasetList:
+    def dataset_list(self, page_size: Optional[int] = 10, public: Optional[bool] = None) -> DatasetList:
         """
         Returns a DatasetList instance for interacting with a list of datasets.
 


### PR DESCRIPTION
This PR resolves the pagination below issues with `hub-sdk `

1. If `page_size` is not set, it leads to errors in data retrieval.
2. Display a rate limiter error message for the API if the rate limit is exceeded, resulting in a 429 status code error.
3. Setting `page_size` to more than half of the database records results in duplicate records on the second page.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Enhancements and Robust Error Handling in Ultralytics HUB-SDK 🚀

### 📊 Key Changes
- **Improved Error Handling:** `ErrorHandler` now handles rate limit errors (HTTP 429) and includes response headers in error messages for more detailed troubleshooting. 🛠️
- **Pagination Calculation:** Introduced `math.ceil` for accurate total pages calculation in paginated lists, ensuring the correct number of pages is displayed even when the total items cannot be evenly divided by page size. 📄➗
- **Default Page Size:** Default page size for model, project, and dataset lists set to 10 items, standardizing pagination behavior across the SDK. 📏

### 🎯 Purpose & Impact
- **Enhanced User Experience:** Better error messages, especially for rate limit exceeded scenarios, help users understand API limits and when they can resume requests. This is crucial for applications relying on the Ultralytics HUB-SDK to interact smoothly with services. ☺️🔒
- **Improved Data Access:** Accurate pagination calculations mean users will have a more reliable and predictable navigation experience through lists of models, projects, and datasets. This enhancement is especially beneficial for UIs displaying these lists. 🌐👀
- **Simplified Interaction:** Setting a standard default page size makes it easier for developers to implement and users to interact with the API, encouraging more uniform usage patterns. 🤖💡