### PR TITLE
Handle Missing Users and Teams by Displaying Error Message Instead of…

### DIFF
--- a/hub_sdk/modules/teams.py
+++ b/hub_sdk/modules/teams.py
@@ -46,12 +46,33 @@ class Teams(CRUDClient):
         Returns:
             (None): The method does not return a value.
         """
-        if self.id:
-            resp = super().read(self.id).json()
-            self.data = resp.get("data", {})
-            self.logger.debug("Team id is %s", self.id)
-        else:
+        if not self.id:
             self.logger.error("No team id has been set. Update the team id or create a team.")
+            return
+
+        try:
+            response = super().read(self.id)
+
+            if response is None:
+                self.logger.error(f"Received no response from the server for team ID: {self.id}")
+                return
+
+            # Check if the response has a .json() method (it should if it's a response object)
+            if not hasattr(response, "json"):
+                self.logger.error(f"Invalid response object received for team ID: {self.id}")
+                return
+
+            resp_data = response.json()
+            if resp_data is None:
+                self.logger.error(f"No data received in the response for team ID: {self.id}")
+                return
+
+            data = resp_data.get("data", {})
+            self.data = self._reconstruct_data(data)
+            self.logger.debug(f"Team data retrieved for ID: {self.id}")
+
+        except Exception as e:
+            self.logger.error(f"An error occurred while retrieving data for team ID: {self.id}, {str(e)}")
 
     def create_team(self, team_data) -> None:
         """

--- a/hub_sdk/modules/users.py
+++ b/hub_sdk/modules/users.py
@@ -45,12 +45,33 @@ class Users(CRUDClient):
         Returns:
             (None): The method does not return a value.
         """
-        if self.id:
-            resp = super().read(self.id).json()
-            self.data = resp.get("data", {})
-            self.logger.debug("user id is %s", self.id)
-        else:
+        if not self.id:
             self.logger.error("No user id has been set. Update the user id or create a user.")
+            return
+
+        try:
+            response = super().read(self.id)
+
+            if response is None:
+                self.logger.error(f"Received no response from the server for user ID: {self.id}")
+                return
+
+            # Check if the response has a .json() method (it should if it's a response object)
+            if not hasattr(response, "json"):
+                self.logger.error(f"Invalid response object received for user ID: {self.id}")
+                return
+
+            resp_data = response.json()
+            if resp_data is None:
+                self.logger.error(f"No data received in the response for user ID: {self.id}")
+                return
+
+            data = resp_data.get("data", {})
+            self.data = self._reconstruct_data(data)
+            self.logger.debug(f"User data retrieved for ID: {self.id}")
+
+        except Exception as e:
+            self.logger.error(f"An error occurred while retrieving data for user ID: {self.id}, {str(e)}")
 
     def create_user(self, user_data: dict) -> None:
         """


### PR DESCRIPTION
This PR ensures that an error message is displayed and empty response for a user and team if their IDs do not exist, instead of raising an exception.