### PR TITLE
Add Exponential Backoff to Model Export Status Check

### DIFF
--- a/tests/features/model.py
+++ b/tests/features/model.py
@@ -159,7 +159,7 @@ class Model(BaseClass):
             "Content-Type": "application/json"
         }
 
-        backoff_times = [10, 20, 40, 80]  # Exponential backoff waits in seconds
+        backoff_times = [60, 120, 240, 480]  # Exponential backoff waits in seconds
 
         for wait_time in backoff_times:
             try:

--- a/tests/features/model.py
+++ b/tests/features/model.py
@@ -154,10 +154,7 @@ class Model(BaseClass):
         url = f"{host}/get-export"
 
         payload = json.dumps({"modelId": model_id, "format": format_name})
-        headers = {
-            "x-api-key": TestData().get_auth_data()["valid_api_key"],
-            "Content-Type": "application/json"
-        }
+        headers = {"x-api-key": TestData().get_auth_data()["valid_api_key"], "Content-Type": "application/json"}
 
         backoff_times = [60, 120, 240, 480]  # Exponential backoff waits in seconds
 


### PR DESCRIPTION
This PR implements an exponential backoff strategy for the `is_model_exported` method to replace the previous fixed 60-second timeout. The new approach improves efficiency and robustness by retrying API requests at increasing intervals, ensuring better handling of export readiness checks and reducing server load.

 I have read the CLA Document and I sign the CLA


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves the model export readiness check by implementing exponential backoff for retries, enhancing stability and error-handling in testing.

### 📊 Key Changes  
- 🕒 Replaced fixed timeout retry mechanism with **exponential backoff** (e.g., 60, 120, 240, 480 seconds) for checking model export readiness.  
- 🚨 Improved error handling: added exception handling to catch and log errors during export checks.  
- 📝 Enhanced logs: added informative retry and failure messages for debugging.

### 🎯 Purpose & Impact  
- ✅ **More reliable tests**: Prevent server overload with smarter retry intervals instead of repeated quick requests.  
- 🚀 **Better debugging**: Clear logging of issues and retries helps identify problems faster.  
- 🔄 **Improved stability**: Reduced chances of failures during testing by gracefully handling errors and delays.