### PR TITLE
Apply `ruff==0.9.0` formatting

### DIFF
--- a/hub_sdk/base/auth.py
+++ b/hub_sdk/base/auth.py
@@ -34,8 +34,7 @@ class Auth:
             (ConnectionError): If request response fails, raise connection error exception.
         """
         try:
-            header = self.get_auth_header()
-            if header:
+            if header := self.get_auth_header():
                 r = requests.post(f"{HUB_API_ROOT}/v1/auth", headers=header)
                 if not r.json().get("success", False):
                     raise ConnectionError("Unable to authenticate.")

--- a/tests/functional/test_dataset.py
+++ b/tests/functional/test_dataset.py
@@ -79,9 +79,9 @@ class TestDataset(BaseClass):
 
         log.info(f"Updated dataset name: {updated_dataset_name}")
 
-        assert (
-            updated_dataset_name == desired_dataset_name
-        ), f"Dataset name is not updated as expected. Actual: {updated_dataset_name}, Expected: {desired_dataset_name}"
+        assert updated_dataset_name == desired_dataset_name, (
+            f"Dataset name is not updated as expected. Actual: {updated_dataset_name}, Expected: {desired_dataset_name}"
+        )
 
     @pytest.mark.smoke
     def test_dataset_004(self, request, create_test_dataset):
@@ -104,9 +104,9 @@ class TestDataset(BaseClass):
         log.info("Dataset deleted successfully.")
 
         # Verify if the dataset no longer exists
-        assert not dataset_obj.is_dataset_exists(
-            dataset_id
-        ), f"Dataset with ID {dataset_id} still exists after deletion."
+        assert not dataset_obj.is_dataset_exists(dataset_id), (
+            f"Dataset with ID {dataset_id} still exists after deletion."
+        )
 
     @pytest.mark.smoke
     def test_dataset_005(self):

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -108,7 +108,7 @@ class TestModel(BaseClass):
         log.info(f"Updated model name: {updated_model_name}")
 
         assert updated_model_name == desired_model_name, (
-            f"Model name is not updated as expected. Actual:" f" {updated_model_name}, Expected: {desired_model_name}"
+            f"Model name is not updated as expected. Actual: {updated_model_name}, Expected: {desired_model_name}"
         )
 
     @pytest.mark.smoke

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -77,9 +77,9 @@ class TestProject(BaseClass):
 
         log.info(f"Updated project name: {updated_project_name}")
 
-        assert (
-            updated_project_name == desired_project_name
-        ), f"Project name is not updated as expected. Actual: {updated_project_name}, Expected: {desired_project_name}"
+        assert updated_project_name == desired_project_name, (
+            f"Project name is not updated as expected. Actual: {updated_project_name}, Expected: {desired_project_name}"
+        )
 
     @pytest.mark.smoke
     def test_project_004(self, request, create_test_project):
@@ -102,9 +102,9 @@ class TestProject(BaseClass):
         log.info("Project deleted successfully.")
 
         # Verify if the project no longer exists
-        assert not project_obj.is_project_exists(
-            project_id
-        ), f"Project with ID {project_id} still exists after deletion."
+        assert not project_obj.is_project_exists(project_id), (
+            f"Project with ID {project_id} still exists after deletion."
+        )
 
     @pytest.mark.smoke
     def test_project_005(self):


### PR DESCRIPTION
This [Ultralytics](https://ultralytics.com) PR reformats this repo with the latest improved Ruff version 0.9.0 formatter.

### Learn more about Ultralytics:

- [About Us](https://www.ultralytics.com/about) 🌐
- [Install the Ultralytics App](https://www.ultralytics.com/app-install) 📲
- [Read Our Blog](https://www.ultralytics.com/blog) 📝
- [Learn about YOLO](https://www.ultralytics.com/yolo) 🤖
- [Explore Ultralytics HUB](https://www.ultralytics.com/hub) 🚀
- [Check Out Our Plans](https://www.ultralytics.com/plans) 💼
- [Join our Team](https://www.ultralytics.com/careers) 🌾
- [AI in Healthcare](https://www.ultralytics.com/solutions/ai-in-healthcare) 🏥
- [AI in Manufacturing](https://www.ultralytics.com/solutions/ai-in-manufacturing) 🏭
- [Attend YOLO VISION 2024](https://www.ultralytics.com/events/yolovision) 📅

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Improves authentication code readability and efficiency by simplifying logic. 🔒✨  

### 📊 Key Changes  
- Refactored `authenticate()` method by combining the `get_auth_header()` call and its conditional check into a single line using the walrus operator (`:=`).  

### 🎯 Purpose & Impact  
- **Purpose**: Enhances code clarity and reduces redundancy, ensuring maintainability.  
- **Impact**: Streamlined authentication logic makes it easier for developers to read and debug, with no functional changes for users. 🚀