### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/hub_sdk/__init__.py
+++ b/hub_sdk/__init__.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from hub_sdk.config import HUB_API_ROOT, HUB_WEB_ROOT
 from hub_sdk.hub_client import HUBClient

--- a/hub_sdk/base/__init__.py
+++ b/hub_sdk/base/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/base/api_client.py
+++ b/hub_sdk/base/api_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Dict, Optional
 

--- a/hub_sdk/base/auth.py
+++ b/hub_sdk/base/auth.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Optional
 

--- a/hub_sdk/base/crud_client.py
+++ b/hub_sdk/base/crud_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Optional
 

--- a/hub_sdk/base/paginated_list.py
+++ b/hub_sdk/base/paginated_list.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import math
 from typing import Optional

--- a/hub_sdk/base/server_clients.py
+++ b/hub_sdk/base/server_clients.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 import signal

--- a/hub_sdk/config.py
+++ b/hub_sdk/config.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 

--- a/hub_sdk/helpers/__init__.py
+++ b/hub_sdk/helpers/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/helpers/error_handler.py
+++ b/hub_sdk/helpers/error_handler.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import datetime
 import http.client

--- a/hub_sdk/helpers/exceptions.py
+++ b/hub_sdk/helpers/exceptions.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from hub_sdk.config import HUB_EXCEPTIONS
 

--- a/hub_sdk/helpers/logger.py
+++ b/hub_sdk/helpers/logger.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import logging
 import os

--- a/hub_sdk/helpers/utils.py
+++ b/hub_sdk/helpers/utils.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import threading
 

--- a/hub_sdk/hub_client.py
+++ b/hub_sdk/hub_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 from typing import Dict, Optional

--- a/hub_sdk/modules/__init__.py
+++ b/hub_sdk/modules/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/modules/datasets.py
+++ b/hub_sdk/modules/datasets.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, List, Optional
 

--- a/hub_sdk/modules/projects.py
+++ b/hub_sdk/modules/projects.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/teams.py
+++ b/hub_sdk/modules/teams.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/users.py
+++ b/hub_sdk/modules/users.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 import requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import pytest
 import requests
 

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -1,0 +1,1 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/features/dataset.py
+++ b/tests/features/dataset.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 from tests.utils.base_class import BaseClass
 
 

--- a/tests/features/dataset.py
+++ b/tests/features/dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.utils.base_class import BaseClass
 

--- a/tests/features/model.py
+++ b/tests/features/model.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import json
 import time
 

--- a/tests/features/model.py
+++ b/tests/features/model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
 import time

--- a/tests/features/object_manager.py
+++ b/tests/features/object_manager.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 from tests.features.dataset import Dataset
 from tests.features.model import Model
 from tests.features.project import Project

--- a/tests/features/object_manager.py
+++ b/tests/features/object_manager.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.features.dataset import Dataset
 from tests.features.model import Model

--- a/tests/features/project.py
+++ b/tests/features/project.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 from tests.utils.base_class import BaseClass
 
 

--- a/tests/features/project.py
+++ b/tests/features/project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.utils.base_class import BaseClass
 

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,1 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import pytest
 
 from hub_sdk import HUBClient

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_dataset.py
+++ b/tests/functional/test_dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_dataset.py
+++ b/tests/functional/test_dataset.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import pytest
 
 from tests.features.object_manager import ObjectManager

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import pytest
 
 from tests.features.object_manager import ObjectManager

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import pytest
 
 from tests.features.object_manager import ObjectManager

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/testCase_dataset.py
+++ b/tests/testCase_dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/testCase_model.py
+++ b/tests/testCase_model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/testCase_project.py
+++ b/tests/testCase_project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,0 +1,1 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/test_data/data.py
+++ b/tests/test_data/data.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import json
 
 

--- a/tests/test_data/data.py
+++ b/tests/test_data/data.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/utils/base_class.py
+++ b/tests/utils/base_class.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import inspect
 import logging
 import os

--- a/tests/utils/base_class.py
+++ b/tests/utils/base_class.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import inspect
 import logging

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import base64
 import json

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1,3 +1,5 @@
+# Ultralytics HUB-SDK 🚀, AGPL-3.0 License
+
 import base64
 import json
 import os


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
--->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Added a URL linking to the Ultralytics license in file headers across the project.

### 📊 Key Changes  
- Updated the header in all source and test files to include a URL to the Ultralytics license: `https://ultralytics.com/license`.  
- Standardized licensing information across all modules, helpers, tests, and configurations.

### 🎯 Purpose & Impact  
- **Purpose:** To provide clear, accessible licensing information directly in the codebase.  
- **Impact:** Enhances transparency and compliance by ensuring all users and contributors can easily access the license details. No functional changes to the SDK. 🚀