### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/hub_sdk/__init__.py
+++ b/hub_sdk/__init__.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from hub_sdk.config import HUB_API_ROOT, HUB_WEB_ROOT
 from hub_sdk.hub_client import HUBClient

--- a/hub_sdk/base/__init__.py
+++ b/hub_sdk/base/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/base/api_client.py
+++ b/hub_sdk/base/api_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Dict, Optional
 

--- a/hub_sdk/base/auth.py
+++ b/hub_sdk/base/auth.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Optional
 

--- a/hub_sdk/base/crud_client.py
+++ b/hub_sdk/base/crud_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Optional
 

--- a/hub_sdk/base/paginated_list.py
+++ b/hub_sdk/base/paginated_list.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import math
 from typing import Optional

--- a/hub_sdk/base/server_clients.py
+++ b/hub_sdk/base/server_clients.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 import signal

--- a/hub_sdk/config.py
+++ b/hub_sdk/config.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 

--- a/hub_sdk/helpers/__init__.py
+++ b/hub_sdk/helpers/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/helpers/error_handler.py
+++ b/hub_sdk/helpers/error_handler.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import datetime
 import http.client

--- a/hub_sdk/helpers/exceptions.py
+++ b/hub_sdk/helpers/exceptions.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from hub_sdk.config import HUB_EXCEPTIONS
 

--- a/hub_sdk/helpers/logger.py
+++ b/hub_sdk/helpers/logger.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import logging
 import os

--- a/hub_sdk/helpers/utils.py
+++ b/hub_sdk/helpers/utils.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import threading
 

--- a/hub_sdk/hub_client.py
+++ b/hub_sdk/hub_client.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import os
 from typing import Dict, Optional

--- a/hub_sdk/modules/__init__.py
+++ b/hub_sdk/modules/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/hub_sdk/modules/datasets.py
+++ b/hub_sdk/modules/datasets.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/models.py
+++ b/hub_sdk/modules/models.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, List, Optional
 

--- a/hub_sdk/modules/projects.py
+++ b/hub_sdk/modules/projects.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/teams.py
+++ b/hub_sdk/modules/teams.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/hub_sdk/modules/users.py
+++ b/hub_sdk/modules/users.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from typing import Any, Dict, Optional
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 import requests
-
 from hub_sdk import HUBClient
+
 from tests.features.object_manager import ObjectManager
 from tests.test_data.data import TestData
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,8 @@
 
 import pytest
 import requests
-from hub_sdk import HUBClient
 
+from hub_sdk import HUBClient
 from tests.features.object_manager import ObjectManager
 from tests.test_data.data import TestData
 

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/features/dataset.py
+++ b/tests/features/dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.utils.base_class import BaseClass
 

--- a/tests/features/model.py
+++ b/tests/features/model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
 import time

--- a/tests/features/object_manager.py
+++ b/tests/features/object_manager.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.features.dataset import Dataset
 from tests.features.model import Model

--- a/tests/features/project.py
+++ b/tests/features/project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from tests.utils.base_class import BaseClass
 

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -1,8 +1,8 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
-
 from hub_sdk import HUBClient
+
 from tests.test_data.data import TestData
 from tests.utils.base_class import BaseClass
 

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -1,8 +1,8 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
-from hub_sdk import HUBClient
 
+from hub_sdk import HUBClient
 from tests.test_data.data import TestData
 from tests.utils.base_class import BaseClass
 

--- a/tests/functional/test_dataset.py
+++ b/tests/functional/test_dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/functional/test_project.py
+++ b/tests/functional/test_project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import pytest
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/testCase_dataset.py
+++ b/tests/testCase_dataset.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/testCase_model.py
+++ b/tests/testCase_model.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/testCase_project.py
+++ b/tests/testCase_project.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import unittest
 

--- a/tests/test_data/__init__.py
+++ b/tests/test_data/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/test_data/data.py
+++ b/tests/test_data/data.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,1 +1,1 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license

--- a/tests/utils/base_class.py
+++ b/tests/utils/base_class.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import inspect
 import logging
@@ -6,7 +6,6 @@ import os
 import time
 
 import pytest
-
 from hub_sdk import HUBClient
 
 

--- a/tests/utils/base_class.py
+++ b/tests/utils/base_class.py
@@ -6,6 +6,7 @@ import os
 import time
 
 import pytest
+
 from hub_sdk import HUBClient
 
 

--- a/tests/utils/test_data.py
+++ b/tests/utils/test_data.py
@@ -1,4 +1,4 @@
-# Ultralytics HUB-SDK 🚀 AGPL-3.0 License - https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import base64
 import json


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Removed "HUB-SDK" branding from code comments across the Ultralytics Hub-SDK repository.

### 📊 Key Changes
- Updated all file comments to replace "Ultralytics HUB-SDK" with "Ultralytics".
- No code logic or functionality was changed, only comment headers.

### 🎯 Purpose & Impact
- **Purpose:** Simplify and rebrand repository headers by removing "HUB-SDK" mention.
- **Impact:** No functional impact on usage or performance. This change is purely cosmetic, ensuring consistency in branding. ✅