### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,8 @@ jobs:
     needs: [check, publish]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract PR Details


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/hub-sdk/security/code-scanning/6](https://github.com/ultralytics/hub-sdk/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `notify` job. This block will explicitly define the minimal permissions required for the job. Based on the job's functionality, it only needs `contents: read` to access repository metadata. No write permissions are necessary.

The `permissions` block will be added under the `notify` job definition, ensuring that the job does not inherit unnecessary permissions from the repository or workflow defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
