### PR TITLE
Update CI workflow to use uv for faster package installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: "pip" # caching pip dependencies
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
       - name: Install Dependencies
         run: |
-          pip install -e ".[dev]"
+          uv pip install --system -e ".[dev]"
         shell: bash
       - name: Build Docs and Check for Warnings
         run: |
@@ -48,10 +50,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: false
       - name: Install dependencies
         run: |
           cd tests
-          pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
       - name: Download Test Data
         run: |
           cd tests


### PR DESCRIPTION
Replace `pip` with `uv pip install --system` for improved build performance and add `setup-uv@v6` action to both Docs and Tests jobs