### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
       - name: Install Dependencies


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/ci.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the CI workflow to use a newer version of the `setup-uv` GitHub Action, helping keep the repository’s automation up to date.

### 📊 Key Changes
- Updated `.github/workflows/ci.yml`
- Bumped the GitHub Action `astral-sh/setup-uv` from `v7` to `v8`
- Kept the rest of the CI setup unchanged, including Python 3.13 and disabled UV cache settings

### 🎯 Purpose & Impact
- Improves CI maintenance by aligning the project with the latest supported version of the `setup-uv` action 🚀
- May provide better reliability, compatibility, or upstream fixes from the newer action release
- Low-risk infrastructure change since it only affects automated workflow setup, not SDK runtime behavior for users 👌
- Helps future-proof development and testing pipelines for contributors and maintainers 🛠️