### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use `astral-sh/setup-uv@v8` instead of `@v7` when publishing the `hub-sdk` package.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/publish.yml`:
  - from `astral-sh/setup-uv@v7`
  - to `astral-sh/setup-uv@v8`
- No application code or SDK functionality was changed.
- The update only affects the automated package publishing pipeline.

### 🎯 Purpose & Impact
- Improves CI/CD maintenance by keeping the publishing workflow aligned with the latest supported GitHub Action version 🚀
- May provide better reliability, compatibility, and upstream fixes from the newer `setup-uv` release 🛠️
- Low-risk change for users, since it does not modify SDK features or APIs ✅
- Helps reduce technical debt and keeps release infrastructure current for future package publishing 📦