### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
       - name: Install Dependencies
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: false
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔄 This PR updates the GitHub Actions setup for `uv` from `astral-sh/setup-uv@v7` to `@v8` across CI and publishing workflows to keep automation current and reliable.

### 📊 Key Changes
- 🛠️ Updated `.github/workflows/ci.yml` to use `astral-sh/setup-uv@v8` instead of `@v7` in both CI jobs.
- 📦 Updated `.github/workflows/publish.yml` to use `astral-sh/setup-uv@v8` in all publish-related jobs.
- ✅ No application or SDK source code was changed; this is a workflow/infrastructure maintenance update only.
- 🚀 Affects both testing and release pipelines, including dependency installation, package building, and SBOM-related steps.

### 🎯 Purpose & Impact
- 🔒 Keeps the repository aligned with the latest supported GitHub Action version for `uv`.
- ⚙️ Helps improve CI/CD stability and reduces the risk of issues caused by outdated workflow dependencies.
- 📈 Makes future maintenance easier by staying current with upstream action updates.
- 🙌 End users likely won’t see any direct SDK behavior changes, but developers and maintainers may benefit from smoother testing and publishing workflows.