### PR TITLE
Set explicit workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@
 
 name: HUB-SDK CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,6 +10,9 @@
 
 name: Check Broken links
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,11 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: "0 0 * * *" # Runs at 00:00 UTC every day


### PR DESCRIPTION
## Summary
- add explicit read-only workflow permissions to CI and link checks
- add stale workflow issue/PR write permissions at workflow scope

## CodeQL alerts
Addresses:
- https://github.com/ultralytics/hub-sdk/security/code-scanning/5
- https://github.com/ultralytics/hub-sdk/security/code-scanning/12
- https://github.com/ultralytics/hub-sdk/security/code-scanning/13
- https://github.com/ultralytics/hub-sdk/security/code-scanning/14
- https://github.com/ultralytics/hub-sdk/security/code-scanning/15

## Validation
- Parsed workflow YAML with `yaml.safe_load()`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔒 This PR updates GitHub Actions workflow permissions to follow a more secure, least-privilege setup for CI, link checking, and stale issue management.

### 📊 Key Changes
- Added explicit `permissions` settings to the **CI workflow** so it only has `contents: read`.
- Added explicit `permissions` settings to the **broken links workflow** so it also only has `contents: read`.
- Added explicit `permissions` settings to the **stale issues workflow** with:
  - `issues: write`
  - `pull-requests: write`
- Left workflow behavior unchanged otherwise; this is mainly a permissions and security hardening update 🛡️

### 🎯 Purpose & Impact
- Improves **GitHub Actions security** by limiting each workflow to only the access it actually needs.
- Helps align the repository with **best practices** and GitHub’s recommended permission model ✅
- Reduces risk from overly broad default token permissions in automation workflows.
- Ensures the **stale bot** can still close or manage old issues and PRs properly, while CI and link checks remain read-only.
- Likely no user-facing feature changes, but it strengthens **repository safety and maintainability** for contributors and maintainers 🚀