### PR TITLE
Remove hardcoded Firebase API key

### DIFF
--- a/hub_sdk/config.py
+++ b/hub_sdk/config.py
@@ -4,10 +4,10 @@ import os
 
 HUB_API_ROOT = os.environ.get("ULTRALYTICS_HUB_API", "https://api.ultralytics.com")
 HUB_WEB_ROOT = os.environ.get("ULTRALYTICS_HUB_WEB", "https://hub.ultralytics.com")
+FIREBASE_API_KEY = os.environ.get("ULTRALYTICS_FIREBASE_API_KEY", "FIREBASE_API_KEY")
 FIREBASE_AUTH_URL = os.environ.get(
     "ULTRALYTICS_FIREBASE_AUTH_URL",
-    "http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=AIzaSyDlTep"
-    "-ubgWoafviJJneFL35raoJjWFnOw",
+    f"http://localhost:9099/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key={FIREBASE_API_KEY}",
 )
 HUB_FUNCTIONS_ROOT = f"{HUB_API_ROOT}"
 


### PR DESCRIPTION
## Summary\n- replace the hardcoded Firebase/Google API key with an environment-driven placeholder\n- preserve the existing local emulator URL default\n\n## Security\nAddresses the open Google API Key secret scanning alert.\n\n## Validation\n- python -m compileall -q hub_sdk/config.py\n- git diff --check

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔐 This PR makes the Firebase authentication API key configurable through an environment variable instead of hardcoding it in the default auth URL.

### 📊 Key Changes
- Added a new config value: `FIREBASE_API_KEY`, loaded from the `ULTRALYTICS_FIREBASE_API_KEY` environment variable.
- Updated `FIREBASE_AUTH_URL` to build its default URL using `FIREBASE_API_KEY` dynamically.
- Removed the previously hardcoded Firebase API key from the authentication URL string.

### 🎯 Purpose & Impact
- Improves 🔒 security and flexibility by avoiding a fixed API key in the codebase.
- Makes local and custom environment setup easier, since teams can now provide their own Firebase API key through environment variables.
- Helps support different deployment environments more cleanly, such as development, testing, and production.
- Reduces maintenance risk by centralizing the API key configuration instead of embedding it directly in a URL.