### PR TITLE
Retry heartbeats on transient request failures instead of killing the thread

### DIFF
--- a/hub_sdk/base/server_clients.py
+++ b/hub_sdk/base/server_clients.py
@@ -156,8 +156,11 @@ class ModelUpload(APIClient):
                     "agent": AGENT_NAME,
                     "agentId": self.agent_id,
                 }
-                res = self.post(endpoint, json=payload).json()
-                new_agent_id = res.get("data", {}).get("agentId")
+                response = self.post(endpoint, json=payload)
+                if response is None:  # request failed and was logged by APIClient, retry at next interval
+                    sleep(interval)
+                    continue
+                new_agent_id = response.json().get("data", {}).get("agentId")
 
                 self.logger.debug("Heartbeat sent.")
 


### PR DESCRIPTION
## Retry heartbeats on transient request failures instead of killing the thread

Found in a Sentry sweep of the `ultralytics` project (runpod environment — Platform GPU workers).

### Issues fixed

| Sentry issue | Project | Error | Link |
|---|---|---|---|
| ULTRALYTICS-1XXH | ultralytics (`runpod`) | `AttributeError: 'NoneType' object has no attribute 'json'` | https://ultralytics.sentry.io/issues/6146625301/ |
| ULTRALYTICS-1XXG | ultralytics (`runpod`) | `Failed to start heartbeats: 'NoneType' object has no attribute 'json'` (logger emission of the same crash) | https://ultralytics.sentry.io/issues/6146625271/ |

### Root cause

`APIClient._make_request` has a documented `Optional[Response]` contract: on `requests.RequestException` with `HUB_EXCEPTIONS` enabled (the default) it logs the error and returns `None`. `ModelUpload._start_heartbeats` was the one caller in the repo dereferencing `.json()` without the standard `if response is None:` check (used by `modules/models.py` et al.), so a single transient network failure (timeout/reset/5xx) on a heartbeat POST raised `AttributeError`, and the loop's `except`/`raise` permanently killed the heartbeat thread for the remainder of the training run. Sentry breadcrumbs confirm: ~1 h of healthy heartbeats, one "Unknown error occurred.", then the crash.

### Fix (replacement, net +3 lines)

Honor the documented contract: check `response is None`, sleep the normal interval, and retry — a keepalive loop must survive transient failures, not die on the first one. The `except`/`raise` block is unchanged: with the contract honored, only genuinely unexpected exceptions still propagate.

### Verification

- `python3 -m py_compile` + `ruff check` + `ruff format --check` (120-char convention): clean
- Live-HUB heartbeat integration not runnable locally; the change is the repo's established None-check pattern applied at the one site missing it

### Reviews

- Codex CLI adversarial review: **LGTM** (confirmed the retry path respects `self.alive`/`_stop_heartbeats` semantics identically to the success path)

### Cross-references

Same sweep fixed portal (SAM WebSocket send-after-close: ALPHA-1PP/1PM) and ultralytics (Edge TPU compiler failures discarded: ALPHA-D1/1PF). PRs: ultralytics/portal#2719, ultralytics/ultralytics#25068. Both Sentry issues will be marked resolved in the `ultralytics` project; note the fix ships via a hub-sdk release, so resolution is tied to the next package release consuming it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Improves heartbeat reliability by safely handling failed API requests without crashing the agent. 💓

### 📊 Key Changes
- Added a `None` response check after sending heartbeat requests to the server.
- If a heartbeat request fails, the client now waits until the next interval and retries instead of calling `.json()` on a missing response.
- Keeps existing debug logging and agent ID update behavior unchanged when requests succeed.

### 🎯 Purpose & Impact
- Prevents crashes caused by failed heartbeat API calls. 🛡️
- Improves stability for long-running HUB SDK agents, especially during temporary network or server issues. 🌐
- Makes heartbeat behavior more resilient by relying on the next scheduled retry rather than failing immediately. 🔁