### PR TITLE
Replace dead pytest and stale formatter config with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,27 +84,12 @@ packages = { find = { where = ["."], include = ["hub_sdk", "hub_sdk.*"] } }
 [tool.setuptools.dynamic]
 version = { attr = "hub_sdk.__version__" }
 
-[tool.pytest]
-norecursedirs = [".git", "dist", "build"]
-addopts = "--doctest-modules --durations=30 --color=yes"
-
 [tool.coverage.run]
 source = ["hub_sdk/"]
 data_file = "tests/.coverage"
 
-[tool.isort]
-line_length = 120
-multi_line_output = 0
-
-[tool.yapf]
-based_on_style = "pep8"
-spaces_before_comment = 2
-column_limit = 120
-coalesce_brackets = true
-spaces_around_power_operator = true
-space_between_ending_comma_and_closing_bracket = true
-split_before_closing_bracket = false
-split_before_first_argument = false
+[tool.ruff]
+line-length = 120
 
 [tool.docformatter]
 wrap-summaries = 120


### PR DESCRIPTION
Three `pyproject.toml` tables that no tool reads.

- `[tool.pytest]` is not a table pytest recognises — it reads `[tool.pytest.ini_options]` — so its `norecursedirs` and `addopts` were silently inert. This repo has no runnable test suite (the 22 files under `tests/` target the shut-down HUB API and no workflow invokes pytest), so the table is deleted rather than renamed.
- `[tool.isort]` and `[tool.yapf]` configure tools that run nowhere here: `format.yml` formats this repo with Ruff and docformatter via `ultralytics/actions`, and neither isort nor yapf is referenced anywhere under `.github/`. Replaced with `[tool.ruff] line-length = 120`, matching the line length the action already passes and the rest of the org.

`[tool.coverage.run]` and `[tool.docformatter]` are unchanged.

Verified behavior-neutral: `ruff format --check .` reports all 45 files already formatted, and `ruff check .` returns the same 26 pre-existing `BLE001` findings with and without this diff (BLE001 is in the ignore list `ultralytics/actions` passes, so CI never surfaces them).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Modernizes project tooling by replacing legacy formatting and test configuration with Ruff-based linting. 🛠️

### 📊 Key Changes
- Removed the `[tool.pytest]` configuration from `pyproject.toml`.
- Removed legacy `[tool.isort]` and `[tool.yapf]` formatting settings.
- Added Ruff configuration with a 120-character line-length limit.
- Kept coverage and documentation formatting settings unchanged.

### 🎯 Purpose & Impact
- Simplifies development tooling by consolidating Python linting and formatting configuration under Ruff. ⚡
- Reduces maintenance overhead from multiple legacy tools.
- May require developers and CI workflows to configure pytest options separately, since the project-level pytest settings were removed.
- Enforces consistent line lengths through Ruff across the SDK. ✅